### PR TITLE
build.gradle fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,15 +4,22 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+def _reactNativeVersion = safeExtGet("reactNative", "+")
+def _compileSdkVersion = safeExtGet("compileSdkVersion", 26)
+
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion safeExtGet("buildToolsVersion", "26.0.3")
 
     defaultConfig {
         minSdkVersion 19
@@ -26,9 +33,13 @@ android {
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
+    maven {
+        url "https://maven.google.com"
+    }
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
+
 }


### PR DESCRIPTION
This fixes #4 

Please note I have no experience in Android development whatsoever, I have suspected that issue described in #4 is due to `build.gradle`. 

I have compared current version of `build.gradle` to one that [FastImage has](https://github.com/DylanVann/react-native-fast-image/blob/master/android/build.gradle)

After applying these changes I was able to build android app via:
1. react-native run-android
2. react-native run-android --variant="release"
3. `./gradlew assembleRelease`

I have tested this on 3 different Android devices (Google Pixel 3 XL, Samsung galaxy A(something) and some Sony Xperia) and everything worked 👌 