### PR TITLE
adding windows implementation

### DIFF
--- a/js/RNImageSize.windows.js
+++ b/js/RNImageSize.windows.js
@@ -1,0 +1,10 @@
+import { Image } from 'react-native';
+
+
+const getSize = (uri) => {
+    return new Promise((resolve, reject) => {
+        Image.getSize(uri, (width, height) => resolve({ width, height }), reject);
+    })
+}
+
+export default { getSize };


### PR DESCRIPTION
Added windows implementation for the react-native-image-size. 

Earlier it was only supporting android and ios