### PR TITLE
Fix for failed build in v1.1.4

### DIFF
--- a/android/src/main/java/com/existfragger/rnimagesize/RNImageSizeModule.java
+++ b/android/src/main/java/com/existfragger/rnimagesize/RNImageSizeModule.java
@@ -52,7 +52,7 @@ public class RNImageSizeModule extends ReactContextBaseJavaModule {
                 height = options.outHeight;
                 width = options.outWidth;
             } else {
-                InputStream input = this.reactContext.getContentResolver().openInputStream(Uri.parse(uri));
+                InputStream input = getReactApplicationContext().getContentResolver().openInputStream(Uri.parse(uri));
                 Bitmap bitmap = BitmapFactory.decodeStream((InputStream) input);
                 height = bitmap.getHeight();
                 width = bitmap.getWidth();


### PR DESCRIPTION
I tried to install tag v1.1.4 but got the compilation error. 

![image](https://github.com/eXist-FraGGer/react-native-image-size/assets/17800898/c5adf74d-9033-4e2a-b717-a407a7ef51a9)

So I created fork where I fixed it :)